### PR TITLE
Add Dialyzer for static code analysis with typespecs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,13 @@ sudo: false
 dist: trusty
 language: elixir
 
+env:
+  - MIX_ENV=test
+
 cache:
   directories:
     - $HOME/.mix
+    - _build/test/dialyxir_erlang-20.0.1_elixir-1.5.1_deps-dev.plt 
 
 elixir: 
   - 1.5.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ sudo: false
 dist: trusty
 language: elixir
 
+cache:
+  directories:
+    - $HOME/.mix
+
 elixir: 
   - 1.5.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ otp_release:
 
 script:
   - mix credo --strict
+  - mix dialyzer

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ env:
 cache:
   directories:
     - $HOME/.mix
-    - _build/test/dialyxir_erlang-20.0.1_elixir-1.5.1_deps-dev.plt 
+    - deps
+    - _build
 
 elixir: 
   - 1.5.1

--- a/lib/gcs_signer.ex
+++ b/lib/gcs_signer.ex
@@ -5,6 +5,13 @@ defmodule GcsSigner do
 
   @base_url "https://storage.googleapis.com"
 
+  @type sign_url_opts :: [
+    verb: String.t,
+    md5_digest: String.t,
+    content_type: String.t,
+    expires: integer
+  ]
+
   @doc """
   Generates signed url.
 
@@ -15,6 +22,12 @@ defmodule GcsSigner do
       "https://storage.googleapis.com/my-bucket/my-object.mp4?Expires=15..."
 
   """
+  @spec sign_url(
+    %{client_email: String.t, private_key: String.t},
+    String.t,
+    String.t,
+    sign_url_opts
+  ) :: String.t
   def sign_url(client, bucket, key, opts \\ []) do
     verb = opts[:verb] || "GET"
     md5_digest = opts[:md5_digest] || ""

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule GcsSigner.Mixfile do
       version: "0.1.1",
       elixir: "~> 1.5",
       start_permanent: Mix.env == :prod,
-      deps: deps()
+      deps: deps(),
+      dialyzer: dialyzer()
     ]
   end
 
@@ -23,7 +24,12 @@ defmodule GcsSigner.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [{:ex_doc, ">= 0.0.0", only: :dev},
-     {:credo, "~> 0.8", only: [:dev, :test], runtime: false}]
+     {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
+     {:dialyxir, "~> 0.5", only: [:dev, :test], runtime: false}]
+  end
+
+  defp dialyzer do
+    [plt_add_apps: [:public_key]]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [], [], "hexpm"},
   "credo": {:hex, :credo, "0.8.6", "335f723772d35da499b5ebfdaf6b426bfb73590b6fcbc8908d476b75f8cbca3f", [], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.1", "b331b091720fd93e878137add264bac4f644e1ddae07a70bf7062c7862c4b952", [], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"}}


### PR DESCRIPTION
This PR adds [Dialyzer](http://erlang.org/doc/man/dialyzer.html) via [Dialyxir](https://github.com/jeremyjh/dialyxir) to perform static code analysis based on typespecs. 